### PR TITLE
Support Transport Group

### DIFF
--- a/info.json
+++ b/info.json
@@ -9,16 +9,17 @@
 	"dependencies": [
 		"base >= 0.17.0",
 		"? trucks",
-		"?aai-programmable-vehicles",
-		"?aai-vehicles-chaingunner",
-		"?aai-vehicles-hauler",
-		"?aai-vehicles-flame-tank",
-		"?aai-vehicles-flame-tumbler",
-		"?aai-vehicles-hauler",
-		"?aai-vehicles-laser-tank",
-		"?aai-vehicles-miner",
-		"?aai-vehicles-warden",
-		"?vwtransporter_A16"
+		"? aai-programmable-vehicles",
+		"? aai-vehicles-chaingunner",
+		"? aai-vehicles-hauler",
+		"? aai-vehicles-flame-tank",
+		"? aai-vehicles-flame-tumbler",
+		"? aai-vehicles-hauler",
+		"? aai-vehicles-laser-tank",
+		"? aai-vehicles-miner",
+		"? aai-vehicles-warden",
+		"? vwtransporter_A16",
+		"? SchallTransportGroup"
 	],
 	"description": "Возьмите с собой полностью заряженный и готовый к бою транспорт и отправьте его в путешествие по железной дороге."
 }

--- a/prototypes/items.lua
+++ b/prototypes/items.lua
@@ -1,10 +1,16 @@
+local subgroup_vehrail = "transport"
+
+if mods["SchallTransportGroup"] then
+	subgroup_vehrail = "vehicles-railway"
+end
+
 data:extend({
 	{
 		type = "item",
 		name = "vehicle-wagon",
 		icon = "__VehicleWagon2__/graphics/tech-icon.png",
 		icon_size = 128,
-		subgroup = "transport",
+		subgroup = subgroup_vehrail,
 		order = "a[train-system]-v[vehicle-wagon]",
 		place_result = "vehicle-wagon",
 		stack_size = 5


### PR DESCRIPTION
This is compatibility code for supporting my mod [Transport Group](https://mods.factorio.com/mod/SchallTransportGroup).
Vehicle wagon is placed along with other railway vehicle items.
